### PR TITLE
Fix loops to reference .tex card filenames

### DIFF
--- a/dndItemCards.tex
+++ b/dndItemCards.tex
@@ -76,7 +76,7 @@
 
 
         % Include card data
-        \def\tmpFilename{cards/\filename}
+        \def\tmpFilename{cards/\filename.tex}
         \IfFileExists{\tmpFilename}{ \input{\tmpFilename} }{}
         % Draw the card
         \node[minimum width=\cardwidth, minimum height=\cardheight, draw, rectangle, fill=white, scale=1] at  ({\j * (\cardwidth + 0.12in)}, {-\i * (\cardheight + 0.02in)}) {%
@@ -123,7 +123,7 @@
 
 
         % Include card data
-        \def\tmpFilename{cards/\filename}
+        \def\tmpFilename{cards/\filename.tex}
         \IfFileExists{\tmpFilename}{ \input{\tmpFilename} }{}
 
         % Draw the card


### PR DESCRIPTION
## Summary
- update loops in `dndItemCards.tex` to include `.tex` extension when loading card files

## Testing
- `pdflatex --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684751192d2c832b9d84d95dbc22121a