### PR TITLE
Fix back-side card alignment

### DIFF
--- a/dndItemCards.tex
+++ b/dndItemCards.tex
@@ -111,8 +111,7 @@
         \begingroup % Ensures scope is properly handled
 
         \pgfmathtruncatemacro{\i}{\index / 3}  % Row index
-        \pgfmathtruncatemacro{\j}{mod(\index, 3)}
-        %\pgfmathtruncatemacro{\j}{\index mod 3}  % Column index
+        \pgfmathtruncatemacro{\j}{2 - mod(\index, 3)} % Mirror column for back side
 
         % Reset macros before loading new card
         \renewcommand{\cardtitle}{Useless Rock}


### PR DESCRIPTION
## Summary
- fix column index calculation for back-side of cards so they mirror the front

## Testing
- `pdflatex -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847502a9284832bbd6ef83140fd212d