### PR TITLE
Expand card templates with new stat macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Card files use the macros defined in `itemCommands.tex`. The most common command
 - `\FlavorText{flag}{text}` – italicized descriptive text.
 - `\ChargeMechanics` and `\SpellCasting` – mechanics for charged and spell‑casting items.
 - `\BonusText` and `\CurseText` – additional effects and curses.
+- `\WeaponStatBlock{damage}{weight}{properties}` – table of weapon statistics.
+- `\ArmorStatBlock{ac}{strength}{stealth}{weight}` – table of armor statistics.
+- `\CreatureStats{ac}{hp}{speed}{str}{dex}{con}{int}{wis}{cha}{cr}` – simple creature or NPC stat block.
 
 See the existing files in the `cards/` directory for examples.
 

--- a/cards/ExampleArmor-Leather.tex
+++ b/cards/ExampleArmor-Leather.tex
@@ -1,0 +1,10 @@
+% Example Armor: Leather Armor
+\renewcommand{\cardtitle}{Leather Armor}
+\renewcommand{\cardbg}{img/BGLight.png}
+\renewcommand{\cardimage}{item_pics/Placeholder.png}
+\renewcommand{\carddescfront}{%
+\ItemTags{Light Armor}{common}{0}{creature}
+\ArmorStatBlock{11 + Dex}{--}{--}{10 lb.}
+}
+\renewcommand{\carddescback}{%
+}

--- a/cards/ExampleCreature-Wolf.tex
+++ b/cards/ExampleCreature-Wolf.tex
@@ -1,0 +1,10 @@
+% Example Creature: Wolf
+\renewcommand{\cardtitle}{Wolf}
+\renewcommand{\cardbg}{img/BGLight.png}
+\renewcommand{\cardimage}{item_pics/Placeholder.png}
+\renewcommand{\carddescfront}{%
+\FlavorText{1}{Medium beast, unaligned}
+\CreatureStats{13 (natural armor)}{11 (2d8)}{40 ft.}{12}{15}{12}{3}{12}{6}{1/4}
+}
+\renewcommand{\carddescback}{%
+}

--- a/cards/ExampleWeapon-Sword.tex
+++ b/cards/ExampleWeapon-Sword.tex
@@ -10,10 +10,7 @@ In darkness, the unsheathed blade of this sword sheds moonlight, creating bright
 Furthermore, you have \textbf{+1 bonus} to \textbf{Attack} and \textbf{Damage Rolls} made with this weapon.\\[2ex]
 
 %\begin{center}
-\begin{tabular}{ccc}
-\textbf{Damage} & \textbf{Weight} & \textbf{Properties}\\
-1d8+1 magic & 3 lb. & Versatile (1d10)
-\end{tabular}
+\WeaponStatBlock{1d8+1 magic}{3 lb.}{Versatile (1d10)}
 %\end{center}
 }
 }

--- a/dndItemCards.tex
+++ b/dndItemCards.tex
@@ -40,7 +40,7 @@
 %\def\cardfiles{cardA, cardB, cardC, cardD, cardE, cardF, cardG, cardH}
 % This command lists all the files in the ``cards'' directory:
 % ls cards | grep -Po '.*(?=\.)' | paste -sd, - | xclip -selection clipboard
-\def\cardfiles{ExampleItem-Letter, ExampleSpell-FireBolt, ExampleWeapon-Sword}
+\def\cardfiles{ExampleItem-Letter, ExampleSpell-FireBolt, ExampleWeapon-Sword, ExampleArmor-Leather, ExampleCreature-Wolf}
 
 % Count number of cards dynamically
 \newcount\cardcount

--- a/dndItemCards.tex
+++ b/dndItemCards.tex
@@ -12,6 +12,7 @@
 \usepackage{tikz}
 \usepackage{graphicx}
 \usepackage{pgffor}  % Needed for dynamic loops
+\usepackage{xparse}  % Provides \NewDocumentCommand
 \tcbuselibrary{skins}
 \usepackage{afterpage} % For controlling page breaks
 \usepackage{ifthen} % Add the ifthen package

--- a/itemCommands.tex
+++ b/itemCommands.tex
@@ -1,5 +1,5 @@
 % Custom command definitions for D&D item cards
-% Add your command definitions here
+% Requires the xparse package for \NewDocumentCommand macros
 
 \newcommand{\ItemTags}[4]{% #1=item type, #2=rarity, #3=attunement type (0=none, 1=attunement, 2=special), #4=special attunement requirement
     \ifnum#3=0
@@ -88,7 +88,7 @@
 }
 
 % Weapon statistics table
-\newcommand{\WeaponStatBlock}[3]{%
+\NewDocumentCommand{\WeaponStatBlock}{m m m}{%
   \begin{center}
     \begin{tabular}{ccc}
       \textbf{Damage} & \textbf{Weight} & \textbf{Properties}\\
@@ -99,7 +99,7 @@
 }
 
 % Armor statistics table
-\newcommand{\ArmorStatBlock}[4]{%
+\NewDocumentCommand{\ArmorStatBlock}{m m m m}{%
   \begin{center}
     \begin{tabular}{cccc}
       \textbf{AC} & \textbf{Strength} & \textbf{Stealth} & \textbf{Weight}\\
@@ -110,7 +110,7 @@
 }
 
 % Simplified creature or NPC stat block
-\newcommand{\CreatureStats}[10]{%
+\NewDocumentCommand{\CreatureStats}{m m m m m m m m m m}{%
   \begin{center}
     \begin{tabular}{cccc}
       \textbf{AC} & \textbf{HP} & \textbf{Speed} & \textbf{CR}\\

--- a/itemCommands.tex
+++ b/itemCommands.tex
@@ -87,6 +87,43 @@
   \fi
 }
 
+% Weapon statistics table
+\newcommand{\WeaponStatBlock}[3]{%
+  \begin{center}
+    \begin{tabular}{ccc}
+      \textbf{Damage} & \textbf{Weight} & \textbf{Properties}\\
+      #1 & #2 & #3
+    \end{tabular}
+  \end{center}
+  \vspace{0.5ex}
+}
+
+% Armor statistics table
+\newcommand{\ArmorStatBlock}[4]{%
+  \begin{center}
+    \begin{tabular}{cccc}
+      \textbf{AC} & \textbf{Strength} & \textbf{Stealth} & \textbf{Weight}\\
+      #1 & #2 & #3 & #4
+    \end{tabular}
+  \end{center}
+  \vspace{0.5ex}
+}
+
+% Simplified creature or NPC stat block
+\newcommand{\CreatureStats}[10]{%
+  \begin{center}
+    \begin{tabular}{cccc}
+      \textbf{AC} & \textbf{HP} & \textbf{Speed} & \textbf{CR}\\
+      #1 & #2 & #3 & #10
+    \end{tabular}\\[1ex]
+    \begin{tabular}{cccccc}
+      \textbf{STR} & \textbf{DEX} & \textbf{CON} & \textbf{INT} & \textbf{WIS} & \textbf{CHA}\\
+      #4 & #5 & #6 & #7 & #8 & #9
+    \end{tabular}
+  \end{center}
+  \vspace{0.5ex}
+}
+
 % Schools are:
 %Abjuration, Conjuration, Divination, Enchantment, Evocation, Illusion, Necromancy, Transmutation
 \newcommand{\SpellCardText}[8]{% #1=Spell name, #2=level[10 to turn off], #3=school, #4=casting time, #5=Range, #6=duration, #7={1-concentration, 0-not}, #8=Components


### PR DESCRIPTION
## Summary
- extend `itemCommands.tex` with macros for weapons, armor and creatures
- add sample cards for armor and creatures
- update the sword example to use the new weapon macro
- document the new commands in README
- include new examples in the default card list

## Testing
- `pdflatex dndItemCards.tex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684781a597f8832b8d6bb8a76e8b8e4f